### PR TITLE
fix(eda): AgentListener resume re-evaluation + Memory retention limits

### DIFF
--- a/src/lib/eda/AgentListener.ts
+++ b/src/lib/eda/AgentListener.ts
@@ -121,6 +121,14 @@ export class AgentListener {
     this.unsubscribers.push(
       this.bus.subscribe('session:resume', () => {
         console.log(`[AgentListener:${this.id}] Resumed`);
+        // Re-evaluate after resume if there are messages we haven't responded to
+        // This fixes the bug where agents don't react after session resume (#31)
+        if (this.messagesSinceSpoke > 0 && this.state === 'listening') {
+          // Schedule evaluation with debounce to allow other agents to also resume
+          this.pendingEvaluation = setTimeout(() => {
+            this.evaluateAndReact();
+          }, this.config.evaluationDebounce + Math.random() * 500);
+        }
       }, this.id)
     );
 


### PR DESCRIPTION
## Summary

Fixes two bugs in the EDA (Event-Driven Architecture) layer:

### #31 - AgentListener not re-evaluating after session resume

**Problem:** When a session was paused (e.g., for research) and then resumed, AgentListener instances would not re-evaluate pending messages. Messages received before pause were effectively ignored.

**Solution:** Added re-evaluation logic in the `session:resume` handler:
- Checks if there are pending messages (`messagesSinceSpoke > 0`)
- Verifies the agent is in 'listening' state
- Schedules a new evaluation with debounce to allow other agents to also resume

### #24 - Memory management improvements

**Problem:** `ConversationMemory` arrays grew unbounded, potentially causing memory issues in long sessions.

**Solution:** Implemented configurable retention limits:

| Array | Default Limit |
|-------|--------------|
| summaries | 20 |
| decisions | 50 |
| proposals | 30 |
| keyPoints (per agent) | 10 |
| positions (per agent) | 10 |
| agreements (per agent) | 10 |
| disagreements (per agent) | 10 |

**New capabilities:**
- `setRetentionLimits(limits)` - Configure limits at runtime
- `getMemoryUsage()` - Get current stats and configured limits
- `cleanupInactiveAgents(activeIds)` - Remove state for agents no longer in session
- Limits enforced on session restore (prevents bloat from old saves)
- Smart proposal trimming: completed/rejected proposals removed first, then oldest active

## Testing

- All 342 existing tests pass
- Added 9 new tests for memory retention limits
- Added 2 new tests for session resume re-evaluation

## Files Changed

- `src/lib/eda/AgentListener.ts` - Resume re-evaluation fix
- `src/lib/eda/AgentListener.test.ts` - New test cases
- `src/lib/eda/ConversationMemory.ts` - Retention limits implementation
- `src/lib/eda/ConversationMemory.test.ts` - New test cases

Closes #31, Closes #24