### PR TITLE
[BE] Persona Marketplace - PersonaManager (#16)

### DIFF
--- a/src/lib/personas/PersonaManager.ts
+++ b/src/lib/personas/PersonaManager.ts
@@ -1,0 +1,967 @@
+/**
+ * PersonaManager - CRUD operations for custom personas
+ * 
+ * Manages custom personas for the Persona Marketplace.
+ * Stores personas in ~/.forge/personas/ with JSON files.
+ * 
+ * @module lib/personas/PersonaManager
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { EventEmitter } from 'events';
+import { v4 as uuidv4 } from 'uuid';
+import type {
+  CustomPersona,
+  CreatePersonaInput,
+  UpdatePersonaInput,
+  PersonaFilter,
+  PersonaSort,
+  PersonaValidationResult,
+  PersonaValidationError,
+  PersonaValidationWarning,
+  PersonaChangeEvent,
+  PersonaSet,
+} from './types';
+import { AGENT_PERSONAS, registerCustomPersonas, clearCustomPersonas } from '../../agents/personas';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Default personas directory */
+const DEFAULT_PERSONAS_DIR = path.join(os.homedir(), '.forge', 'personas');
+
+/** Persona sets directory */
+const PERSONA_SETS_DIR = path.join(os.homedir(), '.forge', 'persona-sets');
+
+/** Valid persona colors */
+const VALID_COLORS = ['pink', 'green', 'purple', 'orange', 'blue', 'cyan', 'yellow', 'red', 'gray'];
+
+/** Max lengths for validation */
+const MAX_NAME_LENGTH = 50;
+const MAX_DESCRIPTION_LENGTH = 500;
+const MAX_BACKGROUND_LENGTH = 1000;
+const MAX_SPEAKING_STYLE_LENGTH = 500;
+const MIN_PERSONALITY_TRAITS = 2;
+const MAX_PERSONALITY_TRAITS = 10;
+const MIN_BIASES = 1;
+const MAX_BIASES = 10;
+const MIN_STRENGTHS = 1;
+const MAX_STRENGTHS = 10;
+const MIN_WEAKNESSES = 1;
+const MAX_WEAKNESSES = 5;
+
+// ============================================================================
+// PERSONA MANAGER CLASS
+// ============================================================================
+
+/**
+ * PersonaManager handles CRUD operations for custom personas.
+ * 
+ * Features:
+ * - Load/save personas from ~/.forge/personas/
+ * - Create, read, update, delete personas
+ * - Validate persona data
+ * - Filter and sort personas
+ * - Track favorites and usage
+ * - Manage persona sets
+ * - Integrate with session persona registry
+ * 
+ * @example
+ * ```typescript
+ * const manager = new PersonaManager();
+ * await manager.initialize();
+ * 
+ * // Create a persona
+ * const persona = await manager.create({
+ *   name: 'Alex',
+ *   nameHe: 'אלכס',
+ *   role: 'The Skeptical Developer',
+ *   age: 32,
+ *   background: 'Senior developer with 10 years experience...',
+ *   personality: ['Technical', 'Detail-oriented'],
+ *   biases: ['Prefers code over marketing'],
+ *   strengths: ['Technical accuracy'],
+ *   weaknesses: ['May over-engineer'],
+ *   speakingStyle: 'Technical, precise',
+ *   color: 'blue',
+ *   description: 'A developer persona for tech products',
+ * });
+ * 
+ * // Use in session
+ * manager.applyToSession([persona.id]);
+ * ```
+ */
+export class PersonaManager extends EventEmitter {
+  private personasDir: string;
+  private setsDir: string;
+  private personas: Map<string, CustomPersona> = new Map();
+  private sets: Map<string, PersonaSet> = new Map();
+  private initialized: boolean = false;
+
+  constructor(personasDir?: string, setsDir?: string) {
+    super();
+    this.personasDir = personasDir || DEFAULT_PERSONAS_DIR;
+    this.setsDir = setsDir || PERSONA_SETS_DIR;
+  }
+
+  // ==========================================================================
+  // INITIALIZATION
+  // ==========================================================================
+
+  /**
+   * Initialize the PersonaManager by loading all personas from disk.
+   * Creates the personas directory if it doesn't exist.
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    // Ensure directories exist
+    await this.ensureDirectories();
+
+    // Load all personas
+    await this.loadAllPersonas();
+
+    // Load persona sets
+    await this.loadAllSets();
+
+    this.initialized = true;
+  }
+
+  /**
+   * Ensure personas and sets directories exist
+   */
+  private async ensureDirectories(): Promise<void> {
+    try {
+      await fs.promises.mkdir(this.personasDir, { recursive: true });
+      await fs.promises.mkdir(this.setsDir, { recursive: true });
+    } catch (error) {
+      // Directory might already exist
+    }
+  }
+
+  /**
+   * Load all personas from the personas directory
+   */
+  private async loadAllPersonas(): Promise<void> {
+    this.personas.clear();
+
+    try {
+      const files = await fs.promises.readdir(this.personasDir);
+      const jsonFiles = files.filter((f) => f.endsWith('.json'));
+
+      for (const file of jsonFiles) {
+        try {
+          const filePath = path.join(this.personasDir, file);
+          const content = await fs.promises.readFile(filePath, 'utf-8');
+          const persona = JSON.parse(content) as CustomPersona;
+          
+          // Validate loaded persona
+          const validation = this.validate(persona);
+          if (validation.valid) {
+            this.personas.set(persona.id, persona);
+          } else {
+            console.warn(`[PersonaManager] Invalid persona file ${file}:`, validation.errors);
+          }
+        } catch (err) {
+          console.warn(`[PersonaManager] Failed to load persona file ${file}:`, err);
+        }
+      }
+    } catch (error) {
+      // Directory might not exist yet
+    }
+  }
+
+  /**
+   * Load all persona sets
+   */
+  private async loadAllSets(): Promise<void> {
+    this.sets.clear();
+
+    try {
+      const files = await fs.promises.readdir(this.setsDir);
+      const jsonFiles = files.filter((f) => f.endsWith('.json'));
+
+      for (const file of jsonFiles) {
+        try {
+          const filePath = path.join(this.setsDir, file);
+          const content = await fs.promises.readFile(filePath, 'utf-8');
+          const set = JSON.parse(content) as PersonaSet;
+          this.sets.set(set.id, set);
+        } catch (err) {
+          console.warn(`[PersonaManager] Failed to load persona set ${file}:`, err);
+        }
+      }
+    } catch (error) {
+      // Directory might not exist yet
+    }
+  }
+
+  // ==========================================================================
+  // CRUD OPERATIONS
+  // ==========================================================================
+
+  /**
+   * Create a new custom persona
+   */
+  async create(input: CreatePersonaInput): Promise<CustomPersona> {
+    await this.ensureInitialized();
+
+    const now = new Date().toISOString();
+    const id = this.generateId(input.name);
+
+    const persona: CustomPersona = {
+      // Base AgentPersona fields
+      id,
+      name: input.name,
+      nameHe: input.nameHe,
+      role: input.role,
+      age: input.age,
+      background: input.background,
+      personality: input.personality,
+      biases: input.biases,
+      strengths: input.strengths,
+      weaknesses: input.weaknesses,
+      speakingStyle: input.speakingStyle,
+      color: input.color,
+      avatar: input.avatar,
+
+      // CustomPersona extensions
+      version: '1.0.0',
+      author: input.author || 'user',
+      authorEmail: input.authorEmail,
+      industry: input.industry,
+      tags: input.tags || [],
+      description: input.description,
+      descriptionHe: input.descriptionHe,
+      isBuiltIn: false,
+      isFavorite: false,
+      isPublished: false,
+      usageCount: 0,
+      createdAt: now,
+      updatedAt: now,
+      customPrompt: input.customPrompt,
+      expertise: input.expertise,
+    };
+
+    // Validate before saving
+    const validation = this.validate(persona);
+    if (!validation.valid) {
+      throw new Error(`Invalid persona: ${validation.errors.map((e) => e.message).join(', ')}`);
+    }
+
+    // Save to disk
+    await this.savePersona(persona);
+
+    // Add to cache
+    this.personas.set(persona.id, persona);
+
+    // Emit event
+    this.emitChange('created', persona.id, persona);
+
+    return persona;
+  }
+
+  /**
+   * Get a persona by ID
+   */
+  async get(id: string): Promise<CustomPersona | null> {
+    await this.ensureInitialized();
+    return this.personas.get(id) || null;
+  }
+
+  /**
+   * Get all personas with optional filtering and sorting
+   */
+  async list(filter?: PersonaFilter, sort?: PersonaSort): Promise<CustomPersona[]> {
+    await this.ensureInitialized();
+
+    let personas = Array.from(this.personas.values());
+
+    // Apply filters
+    if (filter) {
+      personas = this.applyFilter(personas, filter);
+    }
+
+    // Apply sorting
+    if (sort) {
+      personas = this.applySort(personas, sort);
+    }
+
+    return personas;
+  }
+
+  /**
+   * Update an existing persona
+   */
+  async update(id: string, input: UpdatePersonaInput): Promise<CustomPersona> {
+    await this.ensureInitialized();
+
+    const existing = this.personas.get(id);
+    if (!existing) {
+      throw new Error(`Persona not found: ${id}`);
+    }
+
+    if (existing.isBuiltIn) {
+      throw new Error('Cannot modify built-in personas');
+    }
+
+    const updated: CustomPersona = {
+      ...existing,
+      ...input,
+      id: existing.id, // Preserve ID
+      isBuiltIn: false, // Cannot become built-in
+      updatedAt: new Date().toISOString(),
+    };
+
+    // Validate before saving
+    const validation = this.validate(updated);
+    if (!validation.valid) {
+      throw new Error(`Invalid persona: ${validation.errors.map((e) => e.message).join(', ')}`);
+    }
+
+    // Save to disk
+    await this.savePersona(updated);
+
+    // Update cache
+    this.personas.set(updated.id, updated);
+
+    // Emit event
+    this.emitChange('updated', updated.id, updated);
+
+    return updated;
+  }
+
+  /**
+   * Delete a persona
+   */
+  async delete(id: string): Promise<void> {
+    await this.ensureInitialized();
+
+    const existing = this.personas.get(id);
+    if (!existing) {
+      throw new Error(`Persona not found: ${id}`);
+    }
+
+    if (existing.isBuiltIn) {
+      throw new Error('Cannot delete built-in personas');
+    }
+
+    // Delete from disk
+    const filePath = path.join(this.personasDir, `${id}.json`);
+    try {
+      await fs.promises.unlink(filePath);
+    } catch (error) {
+      // File might not exist
+    }
+
+    // Remove from cache
+    this.personas.delete(id);
+
+    // Emit event
+    this.emitChange('deleted', id);
+  }
+
+  /**
+   * Duplicate a persona
+   */
+  async duplicate(id: string, newName?: string): Promise<CustomPersona> {
+    await this.ensureInitialized();
+
+    const existing = this.personas.get(id);
+    if (!existing) {
+      throw new Error(`Persona not found: ${id}`);
+    }
+
+    const input: CreatePersonaInput = {
+      name: newName || `${existing.name} (Copy)`,
+      nameHe: existing.nameHe,
+      role: existing.role,
+      age: existing.age,
+      background: existing.background,
+      personality: [...existing.personality],
+      biases: [...existing.biases],
+      strengths: [...existing.strengths],
+      weaknesses: [...existing.weaknesses],
+      speakingStyle: existing.speakingStyle,
+      color: existing.color,
+      description: existing.description,
+      descriptionHe: existing.descriptionHe,
+      industry: existing.industry,
+      tags: [...existing.tags],
+      avatar: existing.avatar,
+      customPrompt: existing.customPrompt,
+      expertise: existing.expertise,
+      author: existing.author,
+    };
+
+    return this.create(input);
+  }
+
+  // ==========================================================================
+  // FAVORITES & USAGE
+  // ==========================================================================
+
+  /**
+   * Toggle favorite status
+   */
+  async toggleFavorite(id: string): Promise<CustomPersona> {
+    const existing = await this.get(id);
+    if (!existing) {
+      throw new Error(`Persona not found: ${id}`);
+    }
+
+    return this.update(id, { isFavorite: !existing.isFavorite });
+  }
+
+  /**
+   * Increment usage count
+   */
+  async incrementUsage(id: string): Promise<void> {
+    const existing = await this.get(id);
+    if (!existing) return;
+
+    const updated: CustomPersona = {
+      ...existing,
+      usageCount: existing.usageCount + 1,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.savePersona(updated);
+    this.personas.set(id, updated);
+  }
+
+  // ==========================================================================
+  // IMPORT / EXPORT
+  // ==========================================================================
+
+  /**
+   * Import a persona from JSON
+   */
+  async import(json: string | object): Promise<CustomPersona> {
+    const data = typeof json === 'string' ? JSON.parse(json) : json;
+
+    // Generate new ID to avoid conflicts
+    const input: CreatePersonaInput = {
+      name: data.name,
+      nameHe: data.nameHe,
+      role: data.role,
+      age: data.age,
+      background: data.background,
+      personality: data.personality,
+      biases: data.biases,
+      strengths: data.strengths,
+      weaknesses: data.weaknesses,
+      speakingStyle: data.speakingStyle,
+      color: data.color,
+      description: data.description || '',
+      descriptionHe: data.descriptionHe,
+      industry: data.industry,
+      tags: data.tags || [],
+      avatar: data.avatar,
+      customPrompt: data.customPrompt,
+      expertise: data.expertise,
+      author: data.author,
+      authorEmail: data.authorEmail,
+    };
+
+    const persona = await this.create(input);
+    this.emitChange('imported', persona.id, persona);
+    return persona;
+  }
+
+  /**
+   * Export a persona to JSON
+   */
+  async export(id: string): Promise<string> {
+    const persona = await this.get(id);
+    if (!persona) {
+      throw new Error(`Persona not found: ${id}`);
+    }
+
+    return JSON.stringify(persona, null, 2);
+  }
+
+  /**
+   * Import built-in personas as editable custom personas
+   */
+  async importBuiltIns(): Promise<CustomPersona[]> {
+    const imported: CustomPersona[] = [];
+
+    for (const builtin of AGENT_PERSONAS) {
+      const input: CreatePersonaInput = {
+        name: builtin.name,
+        nameHe: builtin.nameHe,
+        role: builtin.role,
+        age: builtin.age,
+        background: builtin.background,
+        personality: builtin.personality,
+        biases: builtin.biases,
+        strengths: builtin.strengths,
+        weaknesses: builtin.weaknesses,
+        speakingStyle: builtin.speakingStyle,
+        color: builtin.color,
+        description: `Imported from built-in: ${builtin.role}`,
+        tags: ['built-in', 'imported'],
+      };
+
+      try {
+        const persona = await this.create(input);
+        imported.push(persona);
+      } catch (err) {
+        console.warn(`[PersonaManager] Failed to import ${builtin.name}:`, err);
+      }
+    }
+
+    return imported;
+  }
+
+  // ==========================================================================
+  // SESSION INTEGRATION
+  // ==========================================================================
+
+  /**
+   * Apply custom personas to the current session.
+   * Registers the specified personas as the active personas for debates.
+   * 
+   * @param personaIds - Array of persona IDs to activate
+   * @returns The activated personas as AgentPersona array
+   */
+  async applyToSession(personaIds: string[]): Promise<CustomPersona[]> {
+    await this.ensureInitialized();
+
+    const personas: CustomPersona[] = [];
+
+    for (const id of personaIds) {
+      const persona = this.personas.get(id);
+      if (persona) {
+        personas.push(persona);
+        await this.incrementUsage(id);
+      }
+    }
+
+    if (personas.length === 0) {
+      throw new Error('No valid personas found for the given IDs');
+    }
+
+    // Register with the global persona registry
+    registerCustomPersonas(personas);
+
+    return personas;
+  }
+
+  /**
+   * Clear session personas and revert to built-in defaults
+   */
+  clearSessionPersonas(): void {
+    clearCustomPersonas();
+  }
+
+  /**
+   * Get personas that are compatible with a session's industry/domain
+   */
+  async getCompatiblePersonas(industry?: string, tags?: string[]): Promise<CustomPersona[]> {
+    const filter: PersonaFilter = {};
+    
+    if (industry) {
+      filter.industry = industry;
+    }
+    
+    if (tags && tags.length > 0) {
+      filter.tags = tags;
+    }
+
+    return this.list(filter, { field: 'usageCount', order: 'desc' });
+  }
+
+  // ==========================================================================
+  // PERSONA SETS
+  // ==========================================================================
+
+  /**
+   * Create a new persona set
+   */
+  async createSet(
+    name: string,
+    personaIds: string[],
+    options?: {
+      nameHe?: string;
+      description?: string;
+      descriptionHe?: string;
+      expertise?: string;
+      author?: string;
+    }
+  ): Promise<PersonaSet> {
+    await this.ensureInitialized();
+
+    const now = new Date().toISOString();
+    const id = this.generateId(name);
+
+    const set: PersonaSet = {
+      id,
+      name,
+      nameHe: options?.nameHe,
+      description: options?.description || '',
+      descriptionHe: options?.descriptionHe,
+      personaIds,
+      expertise: options?.expertise,
+      author: options?.author || 'user',
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    // Validate persona IDs exist
+    for (const pid of personaIds) {
+      if (!this.personas.has(pid)) {
+        throw new Error(`Persona not found: ${pid}`);
+      }
+    }
+
+    // Save to disk
+    const filePath = path.join(this.setsDir, `${id}.json`);
+    await fs.promises.writeFile(filePath, JSON.stringify(set, null, 2), 'utf-8');
+
+    // Add to cache
+    this.sets.set(id, set);
+
+    return set;
+  }
+
+  /**
+   * Get a persona set by ID
+   */
+  async getSet(id: string): Promise<PersonaSet | null> {
+    await this.ensureInitialized();
+    return this.sets.get(id) || null;
+  }
+
+  /**
+   * List all persona sets
+   */
+  async listSets(): Promise<PersonaSet[]> {
+    await this.ensureInitialized();
+    return Array.from(this.sets.values());
+  }
+
+  /**
+   * Delete a persona set
+   */
+  async deleteSet(id: string): Promise<void> {
+    await this.ensureInitialized();
+
+    if (!this.sets.has(id)) {
+      throw new Error(`Persona set not found: ${id}`);
+    }
+
+    // Delete from disk
+    const filePath = path.join(this.setsDir, `${id}.json`);
+    try {
+      await fs.promises.unlink(filePath);
+    } catch (error) {
+      // File might not exist
+    }
+
+    this.sets.delete(id);
+  }
+
+  /**
+   * Apply a persona set to the current session
+   */
+  async applySetToSession(setId: string): Promise<CustomPersona[]> {
+    const set = await this.getSet(setId);
+    if (!set) {
+      throw new Error(`Persona set not found: ${setId}`);
+    }
+
+    return this.applyToSession(set.personaIds);
+  }
+
+  // ==========================================================================
+  // VALIDATION
+  // ==========================================================================
+
+  /**
+   * Validate persona data
+   */
+  validate(persona: Partial<CustomPersona>): PersonaValidationResult {
+    const errors: PersonaValidationError[] = [];
+    const warnings: PersonaValidationWarning[] = [];
+
+    // Required fields
+    if (!persona.name || persona.name.trim().length === 0) {
+      errors.push({ field: 'name', message: 'Name is required', code: 'REQUIRED' });
+    } else if (persona.name.length > MAX_NAME_LENGTH) {
+      errors.push({
+        field: 'name',
+        message: `Name must be ${MAX_NAME_LENGTH} characters or less`,
+        code: 'MAX_LENGTH',
+      });
+    }
+
+    if (!persona.nameHe || persona.nameHe.trim().length === 0) {
+      errors.push({ field: 'nameHe', message: 'Hebrew name is required', code: 'REQUIRED' });
+    }
+
+    if (!persona.role || persona.role.trim().length === 0) {
+      errors.push({ field: 'role', message: 'Role is required', code: 'REQUIRED' });
+    }
+
+    if (persona.age === undefined || persona.age < 18 || persona.age > 120) {
+      errors.push({ field: 'age', message: 'Age must be between 18 and 120', code: 'INVALID_RANGE' });
+    }
+
+    if (!persona.background || persona.background.trim().length === 0) {
+      errors.push({ field: 'background', message: 'Background is required', code: 'REQUIRED' });
+    } else if (persona.background.length > MAX_BACKGROUND_LENGTH) {
+      errors.push({
+        field: 'background',
+        message: `Background must be ${MAX_BACKGROUND_LENGTH} characters or less`,
+        code: 'MAX_LENGTH',
+      });
+    }
+
+    // Array fields
+    if (!persona.personality || persona.personality.length < MIN_PERSONALITY_TRAITS) {
+      errors.push({
+        field: 'personality',
+        message: `At least ${MIN_PERSONALITY_TRAITS} personality traits are required`,
+        code: 'MIN_LENGTH',
+      });
+    } else if (persona.personality.length > MAX_PERSONALITY_TRAITS) {
+      errors.push({
+        field: 'personality',
+        message: `Maximum ${MAX_PERSONALITY_TRAITS} personality traits allowed`,
+        code: 'MAX_LENGTH',
+      });
+    }
+
+    if (!persona.biases || persona.biases.length < MIN_BIASES) {
+      errors.push({
+        field: 'biases',
+        message: `At least ${MIN_BIASES} bias is required`,
+        code: 'MIN_LENGTH',
+      });
+    } else if (persona.biases.length > MAX_BIASES) {
+      errors.push({
+        field: 'biases',
+        message: `Maximum ${MAX_BIASES} biases allowed`,
+        code: 'MAX_LENGTH',
+      });
+    }
+
+    if (!persona.strengths || persona.strengths.length < MIN_STRENGTHS) {
+      errors.push({
+        field: 'strengths',
+        message: `At least ${MIN_STRENGTHS} strength is required`,
+        code: 'MIN_LENGTH',
+      });
+    } else if (persona.strengths.length > MAX_STRENGTHS) {
+      errors.push({
+        field: 'strengths',
+        message: `Maximum ${MAX_STRENGTHS} strengths allowed`,
+        code: 'MAX_LENGTH',
+      });
+    }
+
+    if (!persona.weaknesses || persona.weaknesses.length < MIN_WEAKNESSES) {
+      errors.push({
+        field: 'weaknesses',
+        message: `At least ${MIN_WEAKNESSES} weakness is required`,
+        code: 'MIN_LENGTH',
+      });
+    } else if (persona.weaknesses.length > MAX_WEAKNESSES) {
+      errors.push({
+        field: 'weaknesses',
+        message: `Maximum ${MAX_WEAKNESSES} weaknesses allowed`,
+        code: 'MAX_LENGTH',
+      });
+    }
+
+    // Speaking style
+    if (!persona.speakingStyle || persona.speakingStyle.trim().length === 0) {
+      errors.push({ field: 'speakingStyle', message: 'Speaking style is required', code: 'REQUIRED' });
+    } else if (persona.speakingStyle.length > MAX_SPEAKING_STYLE_LENGTH) {
+      errors.push({
+        field: 'speakingStyle',
+        message: `Speaking style must be ${MAX_SPEAKING_STYLE_LENGTH} characters or less`,
+        code: 'MAX_LENGTH',
+      });
+    }
+
+    // Color
+    if (!persona.color || !VALID_COLORS.includes(persona.color)) {
+      errors.push({
+        field: 'color',
+        message: `Color must be one of: ${VALID_COLORS.join(', ')}`,
+        code: 'INVALID_VALUE',
+      });
+    }
+
+    // Warnings for optional but recommended fields
+    if (!persona.description || persona.description.trim().length === 0) {
+      warnings.push({
+        field: 'description',
+        message: 'Description is recommended for marketplace visibility',
+        code: 'RECOMMENDED',
+      });
+    }
+
+    if (!persona.tags || persona.tags.length === 0) {
+      warnings.push({
+        field: 'tags',
+        message: 'Tags are recommended for discoverability',
+        code: 'RECOMMENDED',
+      });
+    }
+
+    if (!persona.industry) {
+      warnings.push({
+        field: 'industry',
+        message: 'Industry is recommended for filtering',
+        code: 'RECOMMENDED',
+      });
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    };
+  }
+
+  // ==========================================================================
+  // PRIVATE HELPERS
+  // ==========================================================================
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      await this.initialize();
+    }
+  }
+
+  private generateId(name: string): string {
+    const slug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    const shortUuid = uuidv4().slice(0, 8);
+    return `${slug}-${shortUuid}`;
+  }
+
+  private async savePersona(persona: CustomPersona): Promise<void> {
+    const filePath = path.join(this.personasDir, `${persona.id}.json`);
+    await fs.promises.writeFile(filePath, JSON.stringify(persona, null, 2), 'utf-8');
+  }
+
+  private applyFilter(personas: CustomPersona[], filter: PersonaFilter): CustomPersona[] {
+    return personas.filter((p) => {
+      if (filter.industry && p.industry !== filter.industry) return false;
+      if (filter.author && p.author !== filter.author) return false;
+      if (filter.favoritesOnly && !p.isFavorite) return false;
+      if (filter.builtInOnly && !p.isBuiltIn) return false;
+      if (filter.customOnly && p.isBuiltIn) return false;
+
+      if (filter.tags && filter.tags.length > 0) {
+        const hasMatchingTag = filter.tags.some((t) => p.tags.includes(t));
+        if (!hasMatchingTag) return false;
+      }
+
+      if (filter.search) {
+        const searchLower = filter.search.toLowerCase();
+        const matches =
+          p.name.toLowerCase().includes(searchLower) ||
+          p.nameHe.includes(filter.search) ||
+          p.description.toLowerCase().includes(searchLower) ||
+          p.role.toLowerCase().includes(searchLower);
+        if (!matches) return false;
+      }
+
+      return true;
+    });
+  }
+
+  private applySort(personas: CustomPersona[], sort: PersonaSort): CustomPersona[] {
+    return [...personas].sort((a, b) => {
+      let comparison = 0;
+
+      switch (sort.field) {
+        case 'name':
+          comparison = a.name.localeCompare(b.name);
+          break;
+        case 'createdAt':
+          comparison = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          break;
+        case 'updatedAt':
+          comparison = new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
+          break;
+        case 'usageCount':
+          comparison = a.usageCount - b.usageCount;
+          break;
+      }
+
+      return sort.order === 'desc' ? -comparison : comparison;
+    });
+  }
+
+  private emitChange(
+    type: PersonaChangeEvent['type'],
+    personaId: string,
+    persona?: CustomPersona
+  ): void {
+    const event: PersonaChangeEvent = {
+      type,
+      personaId,
+      persona,
+      timestamp: new Date().toISOString(),
+    };
+    this.emit('change', event);
+  }
+
+  // ==========================================================================
+  // STATIC HELPERS
+  // ==========================================================================
+
+  /**
+   * Get the default personas directory path
+   */
+  static getDefaultPersonasDir(): string {
+    return DEFAULT_PERSONAS_DIR;
+  }
+
+  /**
+   * Check if the personas directory exists
+   */
+  static async personasDirExists(): Promise<boolean> {
+    try {
+      await fs.promises.access(DEFAULT_PERSONAS_DIR);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+// ============================================================================
+// SINGLETON INSTANCE
+// ============================================================================
+
+let instance: PersonaManager | null = null;
+
+/**
+ * Get the singleton PersonaManager instance
+ */
+export function getPersonaManager(): PersonaManager {
+  if (!instance) {
+    instance = new PersonaManager();
+  }
+  return instance;
+}
+
+/**
+ * Reset the singleton instance (for testing)
+ */
+export function resetPersonaManager(): void {
+  instance = null;
+}

--- a/src/lib/personas/__tests__/PersonaManager.test.ts
+++ b/src/lib/personas/__tests__/PersonaManager.test.ts
@@ -1,0 +1,889 @@
+/**
+ * PersonaManager Tests
+ * 
+ * Comprehensive tests for the Persona Marketplace infrastructure.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { PersonaManager, getPersonaManager, resetPersonaManager } from '../PersonaManager';
+import type { CreatePersonaInput, CustomPersona, PersonaFilter, UpdatePersonaInput } from '../types';
+
+// ============================================================================
+// TEST UTILITIES
+// ============================================================================
+
+const TEST_PERSONAS_DIR = path.join(os.tmpdir(), 'forge-test-personas');
+const TEST_SETS_DIR = path.join(os.tmpdir(), 'forge-test-persona-sets');
+
+/**
+ * Create a valid persona input for testing
+ */
+function createValidInput(overrides: Partial<CreatePersonaInput> = {}): CreatePersonaInput {
+  return {
+    name: 'Test Persona',
+    nameHe: 'פרסונה לבדיקה',
+    role: 'The Test Subject',
+    age: 30,
+    background: 'A test persona created for unit testing the PersonaManager.',
+    personality: ['Analytical', 'Detail-oriented', 'Methodical'],
+    biases: ['Prefers structured approaches', 'Values documentation'],
+    strengths: ['Finding edge cases', 'Thorough analysis', 'Clear communication'],
+    weaknesses: ['May over-analyze', 'Sometimes too rigid'],
+    speakingStyle: 'Technical, precise, uses testing terminology.',
+    color: 'blue',
+    description: 'A persona for testing purposes',
+    industry: 'Technology',
+    tags: ['test', 'development'],
+    ...overrides,
+  };
+}
+
+/**
+ * Clean up test directories
+ */
+async function cleanup(): Promise<void> {
+  try {
+    await fs.promises.rm(TEST_PERSONAS_DIR, { recursive: true, force: true });
+  } catch {
+    // Directory might not exist
+  }
+  try {
+    await fs.promises.rm(TEST_SETS_DIR, { recursive: true, force: true });
+  } catch {
+    // Directory might not exist
+  }
+}
+
+// ============================================================================
+// TEST SUITES
+// ============================================================================
+
+describe('PersonaManager', () => {
+  let manager: PersonaManager;
+
+  beforeEach(async () => {
+    await cleanup();
+    resetPersonaManager();
+    manager = new PersonaManager(TEST_PERSONAS_DIR, TEST_SETS_DIR);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ==========================================================================
+  // INITIALIZATION
+  // ==========================================================================
+
+  describe('Initialization', () => {
+    test('should initialize successfully', async () => {
+      await manager.initialize();
+      const personas = await manager.list();
+      expect(Array.isArray(personas)).toBe(true);
+    });
+
+    test('should create personas directory if it does not exist', async () => {
+      await manager.initialize();
+      const exists = await fs.promises
+        .access(TEST_PERSONAS_DIR)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+    });
+
+    test('should only initialize once', async () => {
+      await manager.initialize();
+      await manager.initialize();
+      // Should not throw
+      const personas = await manager.list();
+      expect(Array.isArray(personas)).toBe(true);
+    });
+
+    test('should load existing personas on initialization', async () => {
+      // Create a persona file manually
+      await fs.promises.mkdir(TEST_PERSONAS_DIR, { recursive: true });
+      const persona: CustomPersona = {
+        id: 'manual-persona',
+        name: 'Manual',
+        nameHe: 'ידני',
+        role: 'Manual Role',
+        age: 25,
+        background: 'Created manually for testing.',
+        personality: ['Test', 'Manual'],
+        biases: ['Testing bias'],
+        strengths: ['Testing strength'],
+        weaknesses: ['Testing weakness'],
+        speakingStyle: 'Manual style',
+        color: 'green',
+        version: '1.0.0',
+        author: 'test',
+        tags: [],
+        description: 'Manual test',
+        isBuiltIn: false,
+        isFavorite: false,
+        isPublished: false,
+        usageCount: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await fs.promises.writeFile(
+        path.join(TEST_PERSONAS_DIR, 'manual-persona.json'),
+        JSON.stringify(persona),
+        'utf-8'
+      );
+
+      await manager.initialize();
+      const loaded = await manager.get('manual-persona');
+      expect(loaded).not.toBeNull();
+      expect(loaded?.name).toBe('Manual');
+    });
+  });
+
+  // ==========================================================================
+  // CREATE
+  // ==========================================================================
+
+  describe('Create', () => {
+    test('should create a persona with valid input', async () => {
+      const input = createValidInput();
+      const persona = await manager.create(input);
+
+      expect(persona).toBeDefined();
+      expect(persona.id).toBeDefined();
+      expect(persona.name).toBe(input.name);
+      expect(persona.nameHe).toBe(input.nameHe);
+      expect(persona.role).toBe(input.role);
+      expect(persona.age).toBe(input.age);
+      expect(persona.background).toBe(input.background);
+      expect(persona.personality).toEqual(input.personality);
+      expect(persona.biases).toEqual(input.biases);
+      expect(persona.strengths).toEqual(input.strengths);
+      expect(persona.weaknesses).toEqual(input.weaknesses);
+      expect(persona.speakingStyle).toBe(input.speakingStyle);
+      expect(persona.color).toBe(input.color);
+      expect(persona.description).toBe(input.description);
+      expect(persona.industry).toBe(input.industry);
+      expect(persona.tags).toEqual(input.tags);
+      expect(persona.isBuiltIn).toBe(false);
+      expect(persona.isFavorite).toBe(false);
+      expect(persona.usageCount).toBe(0);
+      expect(persona.createdAt).toBeDefined();
+      expect(persona.updatedAt).toBeDefined();
+    });
+
+    test('should generate a unique ID', async () => {
+      const persona1 = await manager.create(createValidInput({ name: 'Persona One' }));
+      const persona2 = await manager.create(createValidInput({ name: 'Persona Two' }));
+
+      expect(persona1.id).not.toBe(persona2.id);
+    });
+
+    test('should save persona to disk', async () => {
+      const persona = await manager.create(createValidInput());
+      const filePath = path.join(TEST_PERSONAS_DIR, `${persona.id}.json`);
+      const exists = await fs.promises
+        .access(filePath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      const saved = JSON.parse(content);
+      expect(saved.name).toBe(persona.name);
+    });
+
+    test('should set default values for optional fields', async () => {
+      const persona = await manager.create(createValidInput({ tags: undefined }));
+      expect(persona.tags).toEqual([]);
+      expect(persona.version).toBe('1.0.0');
+      expect(persona.author).toBe('user');
+    });
+
+    test('should reject invalid input', async () => {
+      const invalid = createValidInput({ name: '' });
+      await expect(manager.create(invalid)).rejects.toThrow('Invalid persona');
+    });
+
+    test('should emit change event on create', async () => {
+      const handler = vi.fn();
+      manager.on('change', handler);
+
+      await manager.create(createValidInput());
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].type).toBe('created');
+    });
+  });
+
+  // ==========================================================================
+  // READ
+  // ==========================================================================
+
+  describe('Read', () => {
+    test('should get persona by ID', async () => {
+      const created = await manager.create(createValidInput());
+      const retrieved = await manager.get(created.id);
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.id).toBe(created.id);
+      expect(retrieved?.name).toBe(created.name);
+    });
+
+    test('should return null for non-existent ID', async () => {
+      const retrieved = await manager.get('non-existent-id');
+      expect(retrieved).toBeNull();
+    });
+
+    test('should list all personas', async () => {
+      await manager.create(createValidInput({ name: 'Persona 1' }));
+      await manager.create(createValidInput({ name: 'Persona 2' }));
+      await manager.create(createValidInput({ name: 'Persona 3' }));
+
+      const all = await manager.list();
+      expect(all).toHaveLength(3);
+    });
+
+    test('should list with filter by industry', async () => {
+      await manager.create(createValidInput({ name: 'Tech', industry: 'Technology' }));
+      await manager.create(createValidInput({ name: 'Finance', industry: 'Finance' }));
+
+      const techOnly = await manager.list({ industry: 'Technology' });
+      expect(techOnly).toHaveLength(1);
+      expect(techOnly[0].name).toBe('Tech');
+    });
+
+    test('should list with filter by tags', async () => {
+      await manager.create(createValidInput({ name: 'P1', tags: ['tag-a', 'tag-b'] }));
+      await manager.create(createValidInput({ name: 'P2', tags: ['tag-b', 'tag-c'] }));
+      await manager.create(createValidInput({ name: 'P3', tags: ['tag-c'] }));
+
+      const withTagA = await manager.list({ tags: ['tag-a'] });
+      expect(withTagA).toHaveLength(1);
+
+      const withTagB = await manager.list({ tags: ['tag-b'] });
+      expect(withTagB).toHaveLength(2);
+    });
+
+    test('should list with search filter', async () => {
+      await manager.create(createValidInput({ name: 'Developer Dan', description: 'A dev' }));
+      await manager.create(createValidInput({ name: 'Manager Mary', description: 'A manager' }));
+
+      const devSearch = await manager.list({ search: 'developer' });
+      expect(devSearch).toHaveLength(1);
+      expect(devSearch[0].name).toBe('Developer Dan');
+    });
+
+    test('should list with sort by name ascending', async () => {
+      await manager.create(createValidInput({ name: 'Zara' }));
+      await manager.create(createValidInput({ name: 'Alice' }));
+      await manager.create(createValidInput({ name: 'Mike' }));
+
+      const sorted = await manager.list(undefined, { field: 'name', order: 'asc' });
+      expect(sorted[0].name).toBe('Alice');
+      expect(sorted[1].name).toBe('Mike');
+      expect(sorted[2].name).toBe('Zara');
+    });
+
+    test('should list with sort by usageCount descending', async () => {
+      const p1 = await manager.create(createValidInput({ name: 'Low Usage' }));
+      const p2 = await manager.create(createValidInput({ name: 'High Usage' }));
+      
+      // Increment usage for p2
+      await manager.incrementUsage(p2.id);
+      await manager.incrementUsage(p2.id);
+      await manager.incrementUsage(p2.id);
+
+      const sorted = await manager.list(undefined, { field: 'usageCount', order: 'desc' });
+      expect(sorted[0].name).toBe('High Usage');
+    });
+
+    test('should list favorites only', async () => {
+      const p1 = await manager.create(createValidInput({ name: 'Fav' }));
+      await manager.create(createValidInput({ name: 'Not Fav' }));
+      await manager.toggleFavorite(p1.id);
+
+      const favs = await manager.list({ favoritesOnly: true });
+      expect(favs).toHaveLength(1);
+      expect(favs[0].name).toBe('Fav');
+    });
+  });
+
+  // ==========================================================================
+  // UPDATE
+  // ==========================================================================
+
+  describe('Update', () => {
+    test('should update persona fields', async () => {
+      const created = await manager.create(createValidInput());
+      const updated = await manager.update(created.id, {
+        name: 'Updated Name',
+        age: 35,
+        description: 'Updated description',
+      });
+
+      expect(updated.name).toBe('Updated Name');
+      expect(updated.age).toBe(35);
+      expect(updated.description).toBe('Updated description');
+      expect(updated.id).toBe(created.id); // ID preserved
+    });
+
+    test('should update timestamp on update', async () => {
+      const created = await manager.create(createValidInput());
+      const originalUpdatedAt = created.updatedAt;
+
+      // Wait a bit to ensure timestamp changes
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const updated = await manager.update(created.id, { name: 'New Name' });
+      expect(updated.updatedAt).not.toBe(originalUpdatedAt);
+    });
+
+    test('should persist update to disk', async () => {
+      const created = await manager.create(createValidInput());
+      await manager.update(created.id, { name: 'Persisted Update' });
+
+      const filePath = path.join(TEST_PERSONAS_DIR, `${created.id}.json`);
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      const saved = JSON.parse(content);
+      expect(saved.name).toBe('Persisted Update');
+    });
+
+    test('should throw for non-existent persona', async () => {
+      await expect(manager.update('non-existent', { name: 'Fail' })).rejects.toThrow(
+        'Persona not found'
+      );
+    });
+
+    test('should reject invalid update', async () => {
+      const created = await manager.create(createValidInput());
+      await expect(manager.update(created.id, { age: 150 })).rejects.toThrow('Invalid persona');
+    });
+
+    test('should emit change event on update', async () => {
+      const handler = vi.fn();
+      manager.on('change', handler);
+
+      const created = await manager.create(createValidInput());
+      handler.mockClear();
+
+      await manager.update(created.id, { name: 'Updated' });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].type).toBe('updated');
+    });
+  });
+
+  // ==========================================================================
+  // DELETE
+  // ==========================================================================
+
+  describe('Delete', () => {
+    test('should delete persona', async () => {
+      const created = await manager.create(createValidInput());
+      await manager.delete(created.id);
+
+      const retrieved = await manager.get(created.id);
+      expect(retrieved).toBeNull();
+    });
+
+    test('should remove file from disk', async () => {
+      const created = await manager.create(createValidInput());
+      const filePath = path.join(TEST_PERSONAS_DIR, `${created.id}.json`);
+
+      await manager.delete(created.id);
+
+      const exists = await fs.promises
+        .access(filePath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(false);
+    });
+
+    test('should throw for non-existent persona', async () => {
+      await expect(manager.delete('non-existent')).rejects.toThrow('Persona not found');
+    });
+
+    test('should emit change event on delete', async () => {
+      const handler = vi.fn();
+      manager.on('change', handler);
+
+      const created = await manager.create(createValidInput());
+      handler.mockClear();
+
+      await manager.delete(created.id);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].type).toBe('deleted');
+    });
+  });
+
+  // ==========================================================================
+  // DUPLICATE
+  // ==========================================================================
+
+  describe('Duplicate', () => {
+    test('should duplicate persona with new ID', async () => {
+      const original = await manager.create(createValidInput({ name: 'Original' }));
+      const duplicate = await manager.duplicate(original.id);
+
+      expect(duplicate.id).not.toBe(original.id);
+      expect(duplicate.name).toBe('Original (Copy)');
+      expect(duplicate.role).toBe(original.role);
+      expect(duplicate.personality).toEqual(original.personality);
+    });
+
+    test('should duplicate with custom name', async () => {
+      const original = await manager.create(createValidInput({ name: 'Original' }));
+      const duplicate = await manager.duplicate(original.id, 'Custom Name');
+
+      expect(duplicate.name).toBe('Custom Name');
+    });
+
+    test('should reset usage count on duplicate', async () => {
+      const original = await manager.create(createValidInput());
+      await manager.incrementUsage(original.id);
+      await manager.incrementUsage(original.id);
+
+      const duplicate = await manager.duplicate(original.id);
+      expect(duplicate.usageCount).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // FAVORITES & USAGE
+  // ==========================================================================
+
+  describe('Favorites and Usage', () => {
+    test('should toggle favorite status', async () => {
+      const created = await manager.create(createValidInput());
+      expect(created.isFavorite).toBe(false);
+
+      const toggled = await manager.toggleFavorite(created.id);
+      expect(toggled.isFavorite).toBe(true);
+
+      const toggled2 = await manager.toggleFavorite(created.id);
+      expect(toggled2.isFavorite).toBe(false);
+    });
+
+    test('should increment usage count', async () => {
+      const created = await manager.create(createValidInput());
+      expect(created.usageCount).toBe(0);
+
+      await manager.incrementUsage(created.id);
+      const updated = await manager.get(created.id);
+      expect(updated?.usageCount).toBe(1);
+
+      await manager.incrementUsage(created.id);
+      const updated2 = await manager.get(created.id);
+      expect(updated2?.usageCount).toBe(2);
+    });
+
+    test('should handle incrementUsage for non-existent persona gracefully', async () => {
+      // Should not throw
+      await manager.incrementUsage('non-existent');
+    });
+  });
+
+  // ==========================================================================
+  // IMPORT / EXPORT
+  // ==========================================================================
+
+  describe('Import and Export', () => {
+    test('should export persona to JSON', async () => {
+      const created = await manager.create(createValidInput({ name: 'Export Test' }));
+      const json = await manager.export(created.id);
+
+      const parsed = JSON.parse(json);
+      expect(parsed.name).toBe('Export Test');
+      expect(parsed.id).toBe(created.id);
+    });
+
+    test('should throw when exporting non-existent persona', async () => {
+      await expect(manager.export('non-existent')).rejects.toThrow('Persona not found');
+    });
+
+    test('should import persona from JSON string', async () => {
+      const json = JSON.stringify(createValidInput({ name: 'Imported' }));
+      const imported = await manager.import(json);
+
+      expect(imported.name).toBe('Imported');
+      expect(imported.id).toBeDefined();
+    });
+
+    test('should import persona from object', async () => {
+      const obj = createValidInput({ name: 'Imported Object' });
+      const imported = await manager.import(obj);
+
+      expect(imported.name).toBe('Imported Object');
+    });
+
+    test('should generate new ID on import to avoid conflicts', async () => {
+      const original = await manager.create(createValidInput({ name: 'Original' }));
+      const json = await manager.export(original.id);
+
+      const imported = await manager.import(json);
+      expect(imported.id).not.toBe(original.id);
+    });
+
+    test('should emit imported event', async () => {
+      const handler = vi.fn();
+      manager.on('change', handler);
+
+      await manager.import(createValidInput({ name: 'Import Event' }));
+
+      // Should emit both 'created' and 'imported'
+      const events = handler.mock.calls.map((c) => c[0].type);
+      expect(events).toContain('created');
+      expect(events).toContain('imported');
+    });
+  });
+
+  // ==========================================================================
+  // VALIDATION
+  // ==========================================================================
+
+  describe('Validation', () => {
+    test('should validate valid persona', () => {
+      const result = manager.validate(createValidInput() as any);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('should reject missing name', () => {
+      const result = manager.validate({ ...createValidInput(), name: '' } as any);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'name')).toBe(true);
+    });
+
+    test('should reject name too long', () => {
+      const result = manager.validate({
+        ...createValidInput(),
+        name: 'a'.repeat(100),
+      } as any);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.code === 'MAX_LENGTH' && e.field === 'name')).toBe(true);
+    });
+
+    test('should reject missing Hebrew name', () => {
+      const result = manager.validate({ ...createValidInput(), nameHe: '' } as any);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'nameHe')).toBe(true);
+    });
+
+    test('should reject invalid age', () => {
+      const result = manager.validate({ ...createValidInput(), age: 10 } as any);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'age')).toBe(true);
+    });
+
+    test('should reject age over 120', () => {
+      const result = manager.validate({ ...createValidInput(), age: 150 } as any);
+      expect(result.valid).toBe(false);
+    });
+
+    test('should reject insufficient personality traits', () => {
+      const result = manager.validate({
+        ...createValidInput(),
+        personality: ['Only one'],
+      } as any);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'personality')).toBe(true);
+    });
+
+    test('should reject invalid color', () => {
+      const result = manager.validate({
+        ...createValidInput(),
+        color: 'invalid-color',
+      } as any);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'color')).toBe(true);
+    });
+
+    test('should warn about missing description', () => {
+      const result = manager.validate({
+        ...createValidInput(),
+        description: '',
+      } as any);
+      expect(result.warnings.some((w) => w.field === 'description')).toBe(true);
+    });
+
+    test('should warn about missing tags', () => {
+      const result = manager.validate({
+        ...createValidInput(),
+        tags: [],
+      } as any);
+      expect(result.warnings.some((w) => w.field === 'tags')).toBe(true);
+    });
+
+    test('should warn about missing industry', () => {
+      const result = manager.validate({
+        ...createValidInput(),
+        industry: undefined,
+      } as any);
+      expect(result.warnings.some((w) => w.field === 'industry')).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // SESSION INTEGRATION
+  // ==========================================================================
+
+  describe('Session Integration', () => {
+    test('should apply personas to session', async () => {
+      const p1 = await manager.create(createValidInput({ name: 'Session P1' }));
+      const p2 = await manager.create(createValidInput({ name: 'Session P2' }));
+
+      const applied = await manager.applyToSession([p1.id, p2.id]);
+      expect(applied).toHaveLength(2);
+      expect(applied[0].name).toBe('Session P1');
+      expect(applied[1].name).toBe('Session P2');
+    });
+
+    test('should increment usage when applying to session', async () => {
+      const created = await manager.create(createValidInput());
+      await manager.applyToSession([created.id]);
+
+      const updated = await manager.get(created.id);
+      expect(updated?.usageCount).toBe(1);
+    });
+
+    test('should throw when applying empty persona list', async () => {
+      await expect(manager.applyToSession([])).rejects.toThrow('No valid personas');
+    });
+
+    test('should skip invalid persona IDs when applying', async () => {
+      const valid = await manager.create(createValidInput({ name: 'Valid' }));
+      const applied = await manager.applyToSession([valid.id, 'non-existent']);
+
+      expect(applied).toHaveLength(1);
+      expect(applied[0].name).toBe('Valid');
+    });
+
+    test('should clear session personas', async () => {
+      const created = await manager.create(createValidInput());
+      await manager.applyToSession([created.id]);
+
+      // Should not throw
+      manager.clearSessionPersonas();
+    });
+
+    test('should get compatible personas by industry', async () => {
+      await manager.create(createValidInput({ name: 'Tech 1', industry: 'Technology' }));
+      await manager.create(createValidInput({ name: 'Tech 2', industry: 'Technology' }));
+      await manager.create(createValidInput({ name: 'Finance', industry: 'Finance' }));
+
+      const compatible = await manager.getCompatiblePersonas('Technology');
+      expect(compatible).toHaveLength(2);
+    });
+
+    test('should get compatible personas by tags', async () => {
+      await manager.create(createValidInput({ name: 'P1', tags: ['startup'] }));
+      await manager.create(createValidInput({ name: 'P2', tags: ['enterprise'] }));
+
+      const compatible = await manager.getCompatiblePersonas(undefined, ['startup']);
+      expect(compatible).toHaveLength(1);
+      expect(compatible[0].name).toBe('P1');
+    });
+  });
+
+  // ==========================================================================
+  // PERSONA SETS
+  // ==========================================================================
+
+  describe('Persona Sets', () => {
+    test('should create a persona set', async () => {
+      const p1 = await manager.create(createValidInput({ name: 'Set Member 1' }));
+      const p2 = await manager.create(createValidInput({ name: 'Set Member 2' }));
+
+      const set = await manager.createSet('Test Set', [p1.id, p2.id], {
+        description: 'A test set',
+      });
+
+      expect(set.id).toBeDefined();
+      expect(set.name).toBe('Test Set');
+      expect(set.personaIds).toHaveLength(2);
+    });
+
+    test('should reject set with non-existent persona IDs', async () => {
+      await expect(manager.createSet('Bad Set', ['non-existent'])).rejects.toThrow(
+        'Persona not found'
+      );
+    });
+
+    test('should get persona set by ID', async () => {
+      const p1 = await manager.create(createValidInput());
+      const created = await manager.createSet('Get Test', [p1.id]);
+
+      const retrieved = await manager.getSet(created.id);
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.name).toBe('Get Test');
+    });
+
+    test('should return null for non-existent set', async () => {
+      const retrieved = await manager.getSet('non-existent');
+      expect(retrieved).toBeNull();
+    });
+
+    test('should list all persona sets', async () => {
+      const p1 = await manager.create(createValidInput());
+
+      await manager.createSet('Set 1', [p1.id]);
+      await manager.createSet('Set 2', [p1.id]);
+
+      const sets = await manager.listSets();
+      expect(sets).toHaveLength(2);
+    });
+
+    test('should delete persona set', async () => {
+      const p1 = await manager.create(createValidInput());
+      const set = await manager.createSet('To Delete', [p1.id]);
+
+      await manager.deleteSet(set.id);
+
+      const retrieved = await manager.getSet(set.id);
+      expect(retrieved).toBeNull();
+    });
+
+    test('should throw when deleting non-existent set', async () => {
+      await expect(manager.deleteSet('non-existent')).rejects.toThrow('Persona set not found');
+    });
+
+    test('should apply persona set to session', async () => {
+      const p1 = await manager.create(createValidInput({ name: 'Set Apply 1' }));
+      const p2 = await manager.create(createValidInput({ name: 'Set Apply 2' }));
+      const set = await manager.createSet('Apply Test', [p1.id, p2.id]);
+
+      const applied = await manager.applySetToSession(set.id);
+      expect(applied).toHaveLength(2);
+    });
+
+    test('should throw when applying non-existent set', async () => {
+      await expect(manager.applySetToSession('non-existent')).rejects.toThrow(
+        'Persona set not found'
+      );
+    });
+  });
+
+  // ==========================================================================
+  // SINGLETON
+  // ==========================================================================
+
+  describe('Singleton', () => {
+    test('should return same instance', () => {
+      resetPersonaManager();
+      const instance1 = getPersonaManager();
+      const instance2 = getPersonaManager();
+      expect(instance1).toBe(instance2);
+    });
+
+    test('should reset singleton', () => {
+      const instance1 = getPersonaManager();
+      resetPersonaManager();
+      const instance2 = getPersonaManager();
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  // ==========================================================================
+  // STATIC METHODS
+  // ==========================================================================
+
+  describe('Static Methods', () => {
+    test('should get default personas directory', () => {
+      const dir = PersonaManager.getDefaultPersonasDir();
+      expect(dir).toContain('.forge');
+      expect(dir).toContain('personas');
+    });
+
+    test('should check if personas directory exists', async () => {
+      // Create directory
+      const dir = PersonaManager.getDefaultPersonasDir();
+      await fs.promises.mkdir(dir, { recursive: true });
+
+      const exists = await PersonaManager.personasDirExists();
+      expect(typeof exists).toBe('boolean');
+    });
+  });
+});
+
+// ============================================================================
+// EDGE CASES
+// ============================================================================
+
+describe('PersonaManager Edge Cases', () => {
+  let manager: PersonaManager;
+
+  beforeEach(async () => {
+    await cleanup();
+    resetPersonaManager();
+    manager = new PersonaManager(TEST_PERSONAS_DIR, TEST_SETS_DIR);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  test('should handle special characters in name', async () => {
+    const persona = await manager.create(
+      createValidInput({ name: "Test's Persona (v2.0) [Beta]" })
+    );
+    expect(persona.name).toBe("Test's Persona (v2.0) [Beta]");
+  });
+
+  test('should handle Hebrew in search', async () => {
+    await manager.create(createValidInput({ name: 'Hebrew Test', nameHe: 'בדיקה עברית' }));
+
+    const results = await manager.list({ search: 'בדיקה' });
+    expect(results).toHaveLength(1);
+  });
+
+  test('should handle concurrent creates', async () => {
+    const promises = Array.from({ length: 10 }, (_, i) =>
+      manager.create(createValidInput({ name: `Concurrent ${i}` }))
+    );
+
+    const results = await Promise.all(promises);
+    expect(results).toHaveLength(10);
+
+    const ids = new Set(results.map((r) => r.id));
+    expect(ids.size).toBe(10); // All unique IDs
+  });
+
+  test('should handle empty strings in arrays', async () => {
+    const result = manager.validate({
+      ...createValidInput(),
+      personality: ['Valid', '', 'Another Valid'],
+    } as any);
+    // Empty strings are allowed but may be filtered out in real usage
+    expect(result.valid).toBe(true);
+  });
+
+  test('should handle very long background', async () => {
+    const longBackground = 'a'.repeat(2000);
+    const result = manager.validate({
+      ...createValidInput(),
+      background: longBackground,
+    } as any);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === 'background')).toBe(true);
+  });
+
+  test('should preserve custom prompt on update', async () => {
+    const created = await manager.create(
+      createValidInput({ customPrompt: 'Custom system prompt addition' })
+    );
+    expect(created.customPrompt).toBe('Custom system prompt addition');
+
+    const updated = await manager.update(created.id, { name: 'New Name' });
+    expect(updated.customPrompt).toBe('Custom system prompt addition');
+  });
+
+  test('should handle expertise field', async () => {
+    const expertise = `## Domain Expertise\n\n- Point 1\n- Point 2`;
+    const created = await manager.create(createValidInput({ expertise }));
+    expect(created.expertise).toBe(expertise);
+  });
+});

--- a/src/lib/personas/index.ts
+++ b/src/lib/personas/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Persona Marketplace Module
+ * 
+ * Provides persona management infrastructure for the Copywrite Think Tank.
+ * 
+ * @module lib/personas
+ */
+
+// Types
+export type {
+  CustomPersona,
+  CreatePersonaInput,
+  UpdatePersonaInput,
+  PersonaFilter,
+  PersonaSort,
+  PersonaValidationResult,
+  PersonaValidationError,
+  PersonaValidationWarning,
+  PersonaChangeEvent,
+  PersonaSet,
+} from './types';
+
+// Manager
+export {
+  PersonaManager,
+  getPersonaManager,
+  resetPersonaManager,
+} from './PersonaManager';

--- a/src/lib/personas/types.ts
+++ b/src/lib/personas/types.ts
@@ -1,0 +1,207 @@
+/**
+ * Persona Marketplace Types
+ * 
+ * Defines interfaces for custom personas in the Persona Marketplace.
+ */
+
+import type { AgentPersona } from '../../types';
+
+// ============================================================================
+// CUSTOM PERSONA TYPES
+// ============================================================================
+
+/**
+ * CustomPersona extends AgentPersona with marketplace-specific metadata.
+ * Supports user-created personas, templates, and marketplace distribution.
+ */
+export interface CustomPersona extends AgentPersona {
+  /** Unique identifier for the custom persona */
+  id: string;
+  
+  /** Human-readable name */
+  name: string;
+  
+  /** Hebrew name */
+  nameHe: string;
+  
+  /** Version string for tracking updates */
+  version: string;
+  
+  /** Author/creator identifier */
+  author: string;
+  
+  /** Optional author email */
+  authorEmail?: string;
+  
+  /** Industry or domain this persona is designed for */
+  industry?: string;
+  
+  /** Tags for search and categorization */
+  tags: string[];
+  
+  /** Short description for marketplace listing */
+  description: string;
+  
+  /** Hebrew description */
+  descriptionHe?: string;
+  
+  /** URL to avatar image */
+  avatar?: string;
+  
+  /** Whether this persona is a built-in default */
+  isBuiltIn: boolean;
+  
+  /** Whether this persona is marked as favorite */
+  isFavorite: boolean;
+  
+  /** Whether this persona is published to marketplace */
+  isPublished: boolean;
+  
+  /** Usage count for analytics */
+  usageCount: number;
+  
+  /** ISO timestamp of creation */
+  createdAt: string;
+  
+  /** ISO timestamp of last update */
+  updatedAt: string;
+  
+  /** Optional custom system prompt additions */
+  customPrompt?: string;
+  
+  /** Domain-specific expertise (markdown) */
+  expertise?: string;
+}
+
+/**
+ * Minimal input for creating a new persona
+ */
+export interface CreatePersonaInput {
+  name: string;
+  nameHe: string;
+  role: string;
+  age: number;
+  background: string;
+  personality: string[];
+  biases: string[];
+  strengths: string[];
+  weaknesses: string[];
+  speakingStyle: string;
+  color: string;
+  description: string;
+  descriptionHe?: string;
+  industry?: string;
+  tags?: string[];
+  avatar?: string;
+  customPrompt?: string;
+  expertise?: string;
+  author?: string;
+  authorEmail?: string;
+}
+
+/**
+ * Update input for modifying an existing persona
+ */
+export interface UpdatePersonaInput {
+  name?: string;
+  nameHe?: string;
+  role?: string;
+  age?: number;
+  background?: string;
+  personality?: string[];
+  biases?: string[];
+  strengths?: string[];
+  weaknesses?: string[];
+  speakingStyle?: string;
+  color?: string;
+  description?: string;
+  descriptionHe?: string;
+  industry?: string;
+  tags?: string[];
+  avatar?: string;
+  customPrompt?: string;
+  expertise?: string;
+  isFavorite?: boolean;
+  isPublished?: boolean;
+}
+
+/**
+ * Filter options for listing personas
+ */
+export interface PersonaFilter {
+  /** Filter by industry */
+  industry?: string;
+  
+  /** Filter by tags (any match) */
+  tags?: string[];
+  
+  /** Filter by author */
+  author?: string;
+  
+  /** Include only favorites */
+  favoritesOnly?: boolean;
+  
+  /** Include only built-in personas */
+  builtInOnly?: boolean;
+  
+  /** Include only custom (non-built-in) personas */
+  customOnly?: boolean;
+  
+  /** Search query for name, description, role */
+  search?: string;
+}
+
+/**
+ * Sort options for listing personas
+ */
+export interface PersonaSort {
+  field: 'name' | 'createdAt' | 'updatedAt' | 'usageCount';
+  order: 'asc' | 'desc';
+}
+
+/**
+ * Validation result for persona data
+ */
+export interface PersonaValidationResult {
+  valid: boolean;
+  errors: PersonaValidationError[];
+  warnings: PersonaValidationWarning[];
+}
+
+export interface PersonaValidationError {
+  field: string;
+  message: string;
+  code: string;
+}
+
+export interface PersonaValidationWarning {
+  field: string;
+  message: string;
+  code: string;
+}
+
+/**
+ * Persona set - a collection of personas for a specific domain/project
+ */
+export interface PersonaSet {
+  id: string;
+  name: string;
+  nameHe?: string;
+  description: string;
+  descriptionHe?: string;
+  personaIds: string[];
+  expertise?: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Event emitted when persona data changes
+ */
+export interface PersonaChangeEvent {
+  type: 'created' | 'updated' | 'deleted' | 'imported' | 'favorited';
+  personaId: string;
+  persona?: CustomPersona;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary
Implements the PersonaManager infrastructure for the Persona Marketplace epic.

> 🧹 **Clean PR** - Replaces #45 which had mixed commits

## Changes
- **`src/lib/personas/types.ts`**: Defines `CustomPersona` interface extending `AgentPersona`
- **`src/lib/personas/PersonaManager.ts`**: Full CRUD operations for custom personas
- **`src/lib/personas/index.ts`**: Module exports
- **`src/lib/personas/__tests__/PersonaManager.test.ts`**: 79 comprehensive tests

## Features
- CRUD operations for custom personas
- Persistence in `~/.forge/personas/`
- Validation with errors and warnings
- Filtering by industry, tags, author, favorites
- Import/export JSON
- Persona sets for grouping
- Session integration via `applyToSession()`

## Tests
✅ 79 tests passing

## Related
Closes #16
Part of Epic: Persona Marketplace (#3)
Replaces #45