### PR TITLE
🎨 DrawingBoard UI — Live Visual Consensus Canvas

### DIFF
--- a/src/components/drawingboard/DrawingBoard.tsx
+++ b/src/components/drawingboard/DrawingBoard.tsx
@@ -1,0 +1,309 @@
+/**
+ * DrawingBoard — Live Visual Consensus Canvas
+ * Issue #55: Shared Drawing Board
+ *
+ * Renders the canvas state as ASCII box-drawing wireframes in a side panel.
+ * Shows sections, text blocks, wireframes, notes, and dividers with
+ * consensus status indicators.
+ */
+
+import { useMemo } from 'react';
+import {
+  useCanvasStore,
+  selectSections,
+} from '../../stores/canvasStore';
+import type {
+  CanvasElement,
+  CanvasSection,
+  CanvasText,
+  CanvasWireframe,
+  CanvasNote,
+  CanvasDivider,
+  CanvasStatus,
+} from '../../canvas/types';
+
+// --- Status badges ---
+const STATUS_BADGE: Record<CanvasStatus, { label: string; color: string }> = {
+  proposed: { label: 'draft', color: '#8b949e' },
+  discussed: { label: 'wip', color: '#d29922' },
+  agreed: { label: 'ok', color: '#3fb950' },
+};
+
+function StatusBadge({ status }: { status?: CanvasStatus }) {
+  if (!status) return null;
+  const badge = STATUS_BADGE[status];
+  return (
+    <span style={{ color: badge.color, fontWeight: 600 }}>
+      [{badge.label}]
+    </span>
+  );
+}
+
+// --- Element Renderers ---
+
+function SectionRenderer({ section, children }: { section: CanvasSection; children: CanvasElement[] }) {
+  const textChildren = children.filter((c): c is CanvasText => c.type === 'text');
+  const wireframeChildren = children.filter((c): c is CanvasWireframe => c.type === 'wireframe');
+  const noteChildren = children.filter((c): c is CanvasNote => c.type === 'note');
+
+  return (
+    <div className="canvas-section" style={{
+      border: '1px solid #30363d',
+      borderRadius: '4px',
+      marginBottom: '8px',
+      fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+      fontSize: '12px',
+      backgroundColor: '#0d1117',
+    }}>
+      {/* Section header */}
+      <div style={{
+        padding: '4px 8px',
+        borderBottom: '1px solid #30363d',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        backgroundColor: '#161b22',
+      }}>
+        <span style={{ color: '#58a6ff', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+          {section.label}
+        </span>
+        <StatusBadge status={section.status} />
+      </div>
+
+      {/* Section content */}
+      <div style={{ padding: '6px 8px' }}>
+        {textChildren.map((text, i) => (
+          <TextRenderer key={i} text={text} />
+        ))}
+        {wireframeChildren.map((wf, i) => (
+          <WireframeRenderer key={`wf-${i}`} wireframe={wf} />
+        ))}
+        {noteChildren.map((note, i) => (
+          <NoteRenderer key={`note-${i}`} note={note} />
+        ))}
+        {textChildren.length === 0 && wireframeChildren.length === 0 && noteChildren.length === 0 && (
+          <span style={{ color: '#484f58', fontStyle: 'italic' }}>empty section</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TextRenderer({ text }: { text: CanvasText }) {
+  const roleStyles: Record<string, React.CSSProperties> = {
+    headline: { color: '#f0f6fc', fontSize: '14px', fontWeight: 700 },
+    subtext: { color: '#c9d1d9', fontSize: '12px' },
+    cta: { color: '#58a6ff', fontWeight: 600, textDecoration: 'underline' },
+    body: { color: '#c9d1d9', fontSize: '12px' },
+  };
+
+  const style = roleStyles[text.role] ?? roleStyles.body;
+
+  return (
+    <div style={{
+      padding: '2px 4px',
+      ...style,
+    }}>
+      {text.role === 'cta' ? `[ ${text.content} ]` : text.content}
+    </div>
+  );
+}
+
+function WireframeRenderer({ wireframe }: { wireframe: CanvasWireframe }) {
+  return (
+    <div style={{
+      border: '1px dashed #30363d',
+      borderRadius: '2px',
+      padding: '4px 8px',
+      margin: '4px 0',
+      color: '#8b949e',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '2px' }}>
+        <span style={{ fontSize: '10px', textTransform: 'uppercase' }}>
+          layout: {wireframe.layout}
+        </span>
+        <StatusBadge status={wireframe.status} />
+      </div>
+      <div style={{
+        display: 'flex',
+        gap: '4px',
+        flexWrap: 'wrap',
+      }}>
+        {wireframe.elements.map((el, i) => (
+          <span key={i} style={{
+            border: '1px solid #30363d',
+            padding: '1px 6px',
+            borderRadius: '2px',
+            fontSize: '11px',
+            color: '#c9d1d9',
+          }}>
+            {el}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function NoteRenderer({ note }: { note: CanvasNote }) {
+  return (
+    <div style={{
+      padding: '2px 4px',
+      margin: '2px 0',
+      color: '#d29922',
+      fontSize: '11px',
+      fontStyle: 'italic',
+    }}>
+      💬 <strong>{note.author}</strong>: {note.text}
+    </div>
+  );
+}
+
+function DividerRenderer({ divider }: { divider: CanvasDivider }) {
+  const char = divider.style === 'double' ? '═' : '─';
+  return (
+    <div style={{
+      color: '#30363d',
+      textAlign: 'center',
+      padding: '2px 0',
+      fontSize: '12px',
+      fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+      letterSpacing: '2px',
+    }}>
+      {char.repeat(30)}
+    </div>
+  );
+}
+
+// --- Orphan element renderer (no parent) ---
+function OrphanElementRenderer({ element }: { element: CanvasElement }) {
+  switch (element.type) {
+    case 'text':
+      return <TextRenderer text={element} />;
+    case 'wireframe':
+      return <WireframeRenderer wireframe={element} />;
+    case 'note':
+      return <NoteRenderer note={element} />;
+    case 'divider':
+      return <DividerRenderer divider={element} />;
+    default:
+      return null;
+  }
+}
+
+// --- Main DrawingBoard ---
+
+export function DrawingBoard() {
+  const elements = useCanvasStore((s) => s.elements);
+  const panelVisible = useCanvasStore((s) => s.panelVisible);
+  const lastUpdated = useCanvasStore((s) => s.lastUpdated);
+  const sections = useCanvasStore(selectSections);
+
+  // Build parent → children map
+  const childrenMap = useMemo(() => {
+    const map = new Map<string, CanvasElement[]>();
+    for (const el of elements) {
+      const parent = (el as any).parent;
+      if (parent) {
+        const existing = map.get(parent) ?? [];
+        existing.push(el);
+        map.set(parent, existing);
+      }
+    }
+    return map;
+  }, [elements]);
+
+  // Orphan elements (no parent, not sections)
+  const orphans = useMemo(
+    () => elements.filter((e) => e.type !== 'section' && !('parent' in e && (e as any).parent)),
+    [elements],
+  );
+
+  if (!panelVisible) return null;
+
+  return (
+    <div
+      className="drawing-board-panel"
+      style={{
+        width: '320px',
+        minWidth: '280px',
+        maxWidth: '400px',
+        height: '100%',
+        backgroundColor: '#0d1117',
+        borderLeft: '1px solid #30363d',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div style={{
+        padding: '8px 12px',
+        borderBottom: '1px solid #30363d',
+        backgroundColor: '#161b22',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}>
+        <span style={{ color: '#58a6ff', fontWeight: 700, fontSize: '13px' }}>
+          🎨 Drawing Board
+        </span>
+        <span style={{ color: '#484f58', fontSize: '10px' }}>
+          {elements.length} elements
+        </span>
+      </div>
+
+      {/* Canvas content */}
+      <div style={{
+        flex: 1,
+        overflowY: 'auto',
+        padding: '8px',
+      }}>
+        {elements.length === 0 ? (
+          <div style={{
+            color: '#484f58',
+            textAlign: 'center',
+            padding: '32px 16px',
+            fontSize: '12px',
+          }}>
+            <div style={{ fontSize: '24px', marginBottom: '8px' }}>🖼️</div>
+            Canvas is empty.<br />
+            Agents will draw here as they reach consensus.
+          </div>
+        ) : (
+          <>
+            {/* Render sections with their children */}
+            {sections.map((section) => (
+              <SectionRenderer
+                key={section.id}
+                section={section}
+                children={childrenMap.get(section.id) ?? []}
+              />
+            ))}
+
+            {/* Render orphan elements */}
+            {orphans.map((el, i) => (
+              <OrphanElementRenderer key={`orphan-${i}`} element={el} />
+            ))}
+          </>
+        )}
+      </div>
+
+      {/* Footer */}
+      {lastUpdated && (
+        <div style={{
+          padding: '4px 12px',
+          borderTop: '1px solid #30363d',
+          color: '#484f58',
+          fontSize: '10px',
+          textAlign: 'right',
+        }}>
+          Updated: {new Date(lastUpdated).toLocaleTimeString()}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DrawingBoard;

--- a/src/components/drawingboard/DrawingBoardToggle.tsx
+++ b/src/components/drawingboard/DrawingBoardToggle.tsx
@@ -1,0 +1,51 @@
+/**
+ * DrawingBoardToggle — Toggle button for the Drawing Board panel
+ * Issue #55
+ */
+
+import { useCanvasStore } from '../../stores/canvasStore';
+
+export function DrawingBoardToggle() {
+  const panelVisible = useCanvasStore((s) => s.panelVisible);
+  const togglePanel = useCanvasStore((s) => s.togglePanel);
+  const elementCount = useCanvasStore((s) => s.elements.length);
+
+  return (
+    <button
+      onClick={togglePanel}
+      title={panelVisible ? 'Hide Drawing Board' : 'Show Drawing Board'}
+      style={{
+        background: panelVisible ? '#1f6feb' : '#21262d',
+        border: '1px solid #30363d',
+        borderRadius: '4px',
+        color: panelVisible ? '#ffffff' : '#8b949e',
+        cursor: 'pointer',
+        padding: '4px 8px',
+        fontSize: '12px',
+        fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        transition: 'all 0.15s ease',
+      }}
+    >
+      🎨
+      {elementCount > 0 && (
+        <span style={{
+          backgroundColor: '#3fb950',
+          color: '#0d1117',
+          borderRadius: '8px',
+          padding: '0 5px',
+          fontSize: '10px',
+          fontWeight: 700,
+          minWidth: '16px',
+          textAlign: 'center',
+        }}>
+          {elementCount}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export default DrawingBoardToggle;

--- a/src/components/drawingboard/__tests__/DrawingBoard.test.ts
+++ b/src/components/drawingboard/__tests__/DrawingBoard.test.ts
@@ -1,0 +1,102 @@
+/**
+ * DrawingBoard store + parsing tests
+ * Issue #55
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCanvasStore, selectSections, selectByStatus, selectNotes } from '../../../stores/canvasStore';
+
+const SAMPLE_JSONL = [
+  '{"type":"section","id":"hero","label":"Hero Section","width":80,"status":"agreed"}',
+  '{"type":"text","content":"Ship faster with AI","role":"headline","parent":"hero"}',
+  '{"type":"text","content":"Get Started","role":"cta","parent":"hero"}',
+  '{"type":"section","id":"features","label":"Features","width":80,"status":"discussed"}',
+  '{"type":"wireframe","id":"wf-1","layout":"3-col","elements":["card1","card2","card3"],"parent":"features","status":"proposed"}',
+  '{"type":"note","author":"forge-pm","text":"CTA copy still under debate","parent":"hero"}',
+  '{"type":"divider","style":"single"}',
+].join('\n');
+
+describe('canvasStore', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      elements: [],
+      byId: new Map(),
+      panelVisible: false,
+      lastUpdated: null,
+    });
+  });
+
+  it('loads JSONL and resolves elements', () => {
+    useCanvasStore.getState().loadFromJsonl(SAMPLE_JSONL);
+    const state = useCanvasStore.getState();
+    expect(state.elements.length).toBe(7);
+    expect(state.lastUpdated).toBeTruthy();
+  });
+
+  it('resolves last-write-wins for duplicate ids', () => {
+    const jsonl = [
+      '{"type":"section","id":"hero","label":"Hero v1","width":80,"status":"proposed"}',
+      '{"type":"section","id":"hero","label":"Hero v2","width":80,"status":"agreed"}',
+    ].join('\n');
+
+    useCanvasStore.getState().loadFromJsonl(jsonl);
+    const state = useCanvasStore.getState();
+
+    expect(state.elements.length).toBe(1);
+    expect((state.elements[0] as any).label).toBe('Hero v2');
+    expect((state.elements[0] as any).status).toBe('agreed');
+  });
+
+  it('provides byId lookup', () => {
+    useCanvasStore.getState().loadFromJsonl(SAMPLE_JSONL);
+    const state = useCanvasStore.getState();
+
+    expect(state.byId.get('hero')).toBeTruthy();
+    expect((state.byId.get('hero') as any).label).toBe('Hero Section');
+  });
+
+  it('selectSections returns only sections', () => {
+    useCanvasStore.getState().loadFromJsonl(SAMPLE_JSONL);
+    const sections = selectSections(useCanvasStore.getState());
+    expect(sections.length).toBe(2);
+    expect(sections[0].type).toBe('section');
+  });
+
+  it('selectByStatus filters correctly', () => {
+    useCanvasStore.getState().loadFromJsonl(SAMPLE_JSONL);
+    const agreed = selectByStatus('agreed')(useCanvasStore.getState());
+    expect(agreed.length).toBe(1);
+    expect((agreed[0] as any).id).toBe('hero');
+  });
+
+  it('selectNotes returns notes', () => {
+    useCanvasStore.getState().loadFromJsonl(SAMPLE_JSONL);
+    const notes = selectNotes(useCanvasStore.getState());
+    expect(notes.length).toBe(1);
+    expect(notes[0].author).toBe('forge-pm');
+  });
+
+  it('togglePanel flips visibility', () => {
+    expect(useCanvasStore.getState().panelVisible).toBe(false);
+    useCanvasStore.getState().togglePanel();
+    expect(useCanvasStore.getState().panelVisible).toBe(true);
+    useCanvasStore.getState().togglePanel();
+    expect(useCanvasStore.getState().panelVisible).toBe(false);
+  });
+
+  it('handles empty JSONL gracefully', () => {
+    useCanvasStore.getState().loadFromJsonl('');
+    expect(useCanvasStore.getState().elements.length).toBe(0);
+  });
+
+  it('skips malformed JSON lines', () => {
+    const jsonl = [
+      '{"type":"section","id":"hero","label":"Hero","width":80}',
+      'not valid json',
+      '{"type":"note","author":"test","text":"hello"}',
+    ].join('\n');
+
+    useCanvasStore.getState().loadFromJsonl(jsonl);
+    expect(useCanvasStore.getState().elements.length).toBe(2);
+  });
+});

--- a/src/components/drawingboard/index.ts
+++ b/src/components/drawingboard/index.ts
@@ -1,0 +1,2 @@
+export { DrawingBoard } from './DrawingBoard';
+export { DrawingBoardToggle } from './DrawingBoardToggle';

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -1,0 +1,85 @@
+/**
+ * Canvas Store — Zustand state for Drawing Board UI
+ * Issue #55: Shared Drawing Board — Live Visual Consensus Canvas
+ *
+ * Manages the resolved canvas state from shared/canvas.jsonl
+ * and provides reactive updates for the DrawingBoard component.
+ */
+
+import { create } from 'zustand';
+import type {
+  CanvasElement,
+  CanvasSection,
+  CanvasNote,
+  CanvasStatus,
+} from '../canvas/types';
+
+/** Resolved canvas state — last-write-wins per id, ordered */
+export interface CanvasState {
+  /** All resolved elements in display order */
+  elements: CanvasElement[];
+  /** Map of id → element for quick lookup */
+  byId: Map<string, CanvasElement>;
+  /** Whether the canvas panel is visible */
+  panelVisible: boolean;
+  /** Last update timestamp */
+  lastUpdated: string | null;
+
+  // Actions
+  loadFromJsonl: (jsonlContent: string) => void;
+  togglePanel: () => void;
+  setPanelVisible: (visible: boolean) => void;
+}
+
+/** Parse JSONL content into resolved canvas state */
+function parseJsonl(content: string): { elements: CanvasElement[]; byId: Map<string, CanvasElement> } {
+  const lines = content.trim().split('\n').filter(Boolean);
+  const byId = new Map<string, CanvasElement>();
+  const nonIdElements: CanvasElement[] = [];
+
+  for (const line of lines) {
+    try {
+      const el = JSON.parse(line) as CanvasElement;
+      const id = (el as any).id;
+      if (id) {
+        byId.set(id, el);
+      } else {
+        nonIdElements.push(el);
+      }
+    } catch {
+      // skip malformed
+    }
+  }
+
+  // Ordered: id-based elements first (insertion order), then non-id elements
+  const elements: CanvasElement[] = [...byId.values(), ...nonIdElements];
+  return { elements, byId };
+}
+
+export const useCanvasStore = create<CanvasState>((set) => ({
+  elements: [],
+  byId: new Map(),
+  panelVisible: false,
+  lastUpdated: null,
+
+  loadFromJsonl: (jsonlContent: string) => {
+    const { elements, byId } = parseJsonl(jsonlContent);
+    set({ elements, byId, lastUpdated: new Date().toISOString() });
+  },
+
+  togglePanel: () => set((s) => ({ panelVisible: !s.panelVisible })),
+  setPanelVisible: (visible: boolean) => set({ panelVisible: visible }),
+}));
+
+// Selector helpers
+export const selectSections = (state: CanvasState) =>
+  state.elements.filter((e): e is CanvasSection => e.type === 'section');
+
+export const selectChildrenOf = (parentId: string) => (state: CanvasState) =>
+  state.elements.filter((e) => 'parent' in e && (e as any).parent === parentId);
+
+export const selectByStatus = (status: CanvasStatus) => (state: CanvasState) =>
+  state.elements.filter((e) => 'status' in e && (e as any).status === status);
+
+export const selectNotes = (state: CanvasState) =>
+  state.elements.filter((e): e is CanvasNote => e.type === 'note');


### PR DESCRIPTION
## Summary

Implements the frontend UI for the Shared Drawing Board (Fixes #55).

### What's New

- **DrawingBoard component** — Renders canvas JSONL state as a visual side panel with:
  - Section hierarchy with status badges (`[ok]` / `[wip]` / `[draft]`)
  - Text blocks with role-based styling (headline, subtext, CTA, body)
  - Wireframe layout visualizations with element tags
  - Notes with agent attribution
  - Dividers (single/double style)
  - Empty state when canvas has no elements

- **DrawingBoardToggle** — Compact toggle button with live element count badge

- **canvasStore (Zustand)** — Reactive state management:
  - Parses JSONL content with last-write-wins resolution per element ID
  - Selector helpers: `selectSections`, `selectByStatus`, `selectNotes`, `selectChildrenOf`
  - Panel visibility toggle

### Tests
9 unit tests covering JSONL parsing, last-write-wins, selectors, toggle, empty/malformed input.

### Tech
- React + TypeScript
- Zustand store
- GitHub dark theme styling (matches existing TUI)
- JetBrains Mono font (matches terminal aesthetic)

Fixes #55